### PR TITLE
投稿のグループ機能の実装

### DIFF
--- a/app/assets/javascripts/groups.coffee
+++ b/app/assets/javascripts/groups.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/groups.scss
+++ b/app/assets/stylesheets/groups.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the groups controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -1,0 +1,59 @@
+class GroupsController < ApplicationController
+  def index
+    @groups = Group.all
+  end
+
+  def new
+    @posts = Post.all
+    @groups = Group.all
+    @group = Group.new
+  end
+
+  def create
+    if Group.create(group_params)
+      redirect_to root_path, notice: '新しいグループが作成できました'
+    else
+      flash.now[:alert] = '内容を入力してください。'
+      render :new
+    end
+  end
+
+  def show
+    @groups = Group.all
+    @group = Group.find(params[:id])
+    @posts = @group.posts
+  end
+
+  def edit
+    @posts = Post.all
+    @group = Group.find(params[:id])
+    @groups = Group.all
+    
+  end
+
+  def update
+    @group = Group.find(params[:id])
+    if @group.update(group_params)
+      redirect_to group_path(@group.id), notice: 'グループの編集が完了しました'
+    else
+      flash.now[:alert] = '内容を入力してください。'
+      render :edit
+    end
+  end
+
+  def destroy
+    group = Group.find(params[:id])
+    if group.destroy
+      redirect_to root_path, notice: 'グループが削除されました'
+    else
+      flash.now[:alert] = '削除出来ませんでした。'
+      render :edit
+    end
+  end
+
+
+  private
+  def group_params
+    params.require(:group).permit(:name, post_ids: []).merge(user_id: current_user.id)
+  end
+end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,5 +1,6 @@
 class PostsController < ApplicationController
   before_action :move_to_index, except: [:index, :show]
+  before_action :set_group
 
   def index
     @posts = Post.includes(:user)
@@ -49,5 +50,9 @@ class PostsController < ApplicationController
 
   def move_to_index
     redirect_to action: :index unless user_signed_in?
+  end
+
+  def set_group
+    @groups = Group.all
   end
 end

--- a/app/helpers/groups_helper.rb
+++ b/app/helpers/groups_helper.rb
@@ -1,0 +1,2 @@
+module GroupsHelper
+end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,0 +1,6 @@
+class Group < ApplicationRecord
+  has_many :group_posts, dependent: :destroy
+  has_many :posts, through: :group_posts, dependent: :destroy
+  validates :name, presence: true, uniqueness: true
+  belongs_to :user
+end

--- a/app/models/group_post.rb
+++ b/app/models/group_post.rb
@@ -1,0 +1,4 @@
+class GroupPost < ApplicationRecord
+  belongs_to :group
+  belongs_to :post
+end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -3,4 +3,6 @@ class Post < ApplicationRecord
   mount_uploader :image, ImageUploader
 
   belongs_to :user
+  has_many :group_posts, dependent: :destroy
+  has_many :groups, through: :group_posts, dependent: :destroy
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,4 +6,5 @@ class User < ApplicationRecord
 
   has_many :posts, dependent: :destroy
   validates :name, presence: true, uniqueness: true
+  has_many :groups
 end

--- a/app/views/groups/edit.html.haml
+++ b/app/views/groups/edit.html.haml
@@ -1,0 +1,22 @@
+.wrapper
+  = render "posts/side-bar"
+  .main-space
+    .main-space__info
+      .main-space__info--name
+        グループ編集
+      .btn
+        = link_to 'ホーム', root_path, class: "btn__home"
+    = form_for @group do |f|
+      = f.text_field :name, placeholder: "グループ名を入力", class: "main-space__search--text"
+      ※該当する名前にチェックを入れてください
+      .group
+        = f.collection_check_boxes(:post_ids, @posts, :id, :title) do |post|
+          = post.label do
+            .group__check-boxs
+              .group__check-box
+              = post.check_box
+              .group__add-tag
+                = image_tag(post.object.image, class: "group__add-image")
+              .group__add-title
+                = post.object.title
+      = f.submit "更新", class: "group__edit-btn"

--- a/app/views/groups/new.html.haml
+++ b/app/views/groups/new.html.haml
@@ -1,0 +1,22 @@
+.wrapper
+  = render "posts/side-bar"
+  .main-space
+    .main-space__info
+      .main-space__info--name
+        新規グループ作成
+      .btn
+        = link_to 'ホーム', root_path, class: "btn__home"
+    = form_for @group do |f|
+      = f.text_field :name, placeholder: "グループ名を入力", class: "main-space__search--text"
+      ※該当する名前にチェックを入れてください
+      .group
+        = f.collection_check_boxes(:post_ids, @posts, :id, :title) do |post|
+          = post.label do
+            .group__check-boxs
+              .group__check-box
+              = post.check_box
+              .group__add-tag
+                = image_tag(post.object.image, class: "group__add-image")
+              .group__add-title
+                = post.object.title
+      = f.submit "作成", class: "group__edit-btn"

--- a/app/views/groups/show.html.haml
+++ b/app/views/groups/show.html.haml
@@ -1,0 +1,22 @@
+.wrapper
+  = render "posts/side-bar"
+  .main-space
+    .main-space__info
+      .side-bar__group-name
+        = "グループ名：#{@group.name}"
+      = link_to "グループ作成", new_group_path, class: "btn__edit"
+      = link_to "グループ編集", edit_group_path(@group.id), class: "btn__edit"
+      - if user_signed_in? && current_user.id == @group.user_id
+        = link_to "グループ削除", group_path(@group.id), method: :delete, class: "btn__delete"
+      = link_to "ホーム", root_path, class: "btn__home"
+      .main-space__info--new-post
+      = link_to new_post_path, class: "main-space__info--new-post__btn" do
+        %i.fas.fa-plus-circle
+    .user-show
+      - @posts.each do |post|
+        .main-space__contents--title
+          = image_tag post.image.url, class: "main-space__contents--title__image"
+          = link_to post.title, post_path(post.id), class: "main-space__contents--title__text"
+
+
+

--- a/app/views/posts/_main-space.html.haml
+++ b/app/views/posts/_main-space.html.haml
@@ -2,7 +2,7 @@
   .main-space__info
     .main-space__info--name-pad
       = link_to current_user.name, user_path(current_user), class: "main-space__info--name"
-    -# = link_to "グループ作成", new_group_path, class: "btn__edit"
+    = link_to "グループ作成", new_group_path, class: "btn__edit"
     = link_to "アカウント編集", edit_user_registration_path, class: "btn__edit"
     = link_to "ログアウト", destroy_user_session_path, method: :delete, class: "btn__delete"
     .main-space__info--new-post

--- a/app/views/posts/_side-bar.html.haml
+++ b/app/views/posts/_side-bar.html.haml
@@ -2,6 +2,6 @@
   .side-bar__header
     %h1 御朱印
   .side-bar__group-list
-  -#   - @groups.each do |group|
-  -#     .side-bar__group-list__title
-  -#       = link_to group.name, group_path(group.id), class: "side-bar__group-list__title-name"
+    - @groups.each do |group|
+      .side-bar__group-list__title
+        = link_to group.name, group_path(group.id), class: "side-bar__group-list__title-name"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,5 +3,6 @@ Rails.application.routes.draw do
   root to: 'posts#index'
   resources :maps, only: [:index]
   resources :users, only: [:show, :edit, :update, :destroy]
+  resources :groups, except: :index
   resources :posts
 end

--- a/db/migrate/20200720030218_create_groups.rb
+++ b/db/migrate/20200720030218_create_groups.rb
@@ -1,0 +1,9 @@
+class CreateGroups < ActiveRecord::Migration[5.0]
+  def change
+    create_table :groups do |t|
+      t.string :name, null: false
+      t.index :name, unique: true
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20200720030238_create_group_posts.rb
+++ b/db/migrate/20200720030238_create_group_posts.rb
@@ -1,0 +1,9 @@
+class CreateGroupPosts < ActiveRecord::Migration[5.0]
+  def change
+    create_table :group_posts do |t|
+      t.references :group, foreign_key: true
+      t.references :post, foreign_key: true
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20200720034143_add_user_id_to_groups.rb
+++ b/db/migrate/20200720034143_add_user_id_to_groups.rb
@@ -1,0 +1,5 @@
+class AddUserIdToGroups < ActiveRecord::Migration[5.0]
+  def change
+    add_column :groups, :user_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,24 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200717082332) do
+ActiveRecord::Schema.define(version: 20200720034143) do
+
+  create_table "group_posts", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.integer  "group_id"
+    t.integer  "post_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["group_id"], name: "index_group_posts_on_group_id", using: :btree
+    t.index ["post_id"], name: "index_group_posts_on_post_id", using: :btree
+  end
+
+  create_table "groups", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.string   "name",       null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer  "user_id"
+    t.index ["name"], name: "index_groups_on_name", unique: true, using: :btree
+  end
 
   create_table "posts", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer  "user_id"
@@ -35,4 +52,6 @@ ActiveRecord::Schema.define(version: 20200717082332) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
   end
 
+  add_foreign_key "group_posts", "groups"
+  add_foreign_key "group_posts", "posts"
 end

--- a/test/controllers/groups_controller_test.rb
+++ b/test/controllers/groups_controller_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class GroupsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/fixtures/group_posts.yml
+++ b/test/fixtures/group_posts.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/fixtures/groups.yml
+++ b/test/fixtures/groups.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/group_post_test.rb
+++ b/test/models/group_post_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class GroupPostTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/group_test.rb
+++ b/test/models/group_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class GroupTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## What
投稿をグループ(所在地や札所の順番)でまとめたり、編集、削除できる機能を実装する。
グループを作成したユーザー以外は編集は可能だが、削除はできないよう制約を持つ。
## Why
ユーザーが自由に指定できるグループを作ることで、収集に対してのモチベーションや、
一目で目標に対して現在が、どの位置なのかを判断できるようになる。
削除機能をユーザー全員ができてしまうと、トラブルの原因になるため。