### PR TITLE
投稿編集ページで投稿済の画像を表示する

### DIFF
--- a/app/views/posts/edit.html.haml
+++ b/app/views/posts/edit.html.haml
@@ -7,6 +7,12 @@
         = f.file_field :image, class: "new-content__image--file"
       .new-content__image--explanation
         ここに写真をアップロード
+      - if @post.image.present?
+        = image_tag @post.image, id: :img_prev
+      - else
+        = image_tag "34_chiyo005.jpg", id: :img_prev
+      .new-content__image--js
+        ※アップロードした画像が表示されます
       .new-content__title-areas
         = f.text_field :title, placeholder: :寺、神社の名前, class: "new-content__title"
       .new-content__text-areas

--- a/app/views/posts/new.html.haml
+++ b/app/views/posts/new.html.haml
@@ -8,7 +8,7 @@
       .new-content__image--explanation
         ここに写真をアップロード
       - if @post.image.present?
-        = image_tag @user.image, id: :img_prev
+        = image_tag @post.image, id: :img_prev
       - else
         = image_tag "34_chiyo005.jpg", id: :img_prev
       .new-content__image--js


### PR DESCRIPTION
## What
投稿の編集ページで投稿済の画像を表示する。
## Why
編集前の画像を表示しておくことで、ユーザーのミスやトラブルを防止できるため。