### PR TITLE
コメント日時表示の実装

### DIFF
--- a/app/assets/javascripts/comment.js
+++ b/app/assets/javascripts/comment.js
@@ -2,11 +2,16 @@ $(document).on('turbolinks:load', function(){
   $(function(){
     function buildHTML(comment){
       var html = `<div class="container__comments">
+                    <div class="container__comments--all">
                     <p>
                       <a class="container__comments--name" href=/users/${comment.user_id}>${comment.user_name}</a>
                       ：
                     ${comment.text}
                     </p>
+                      <div class="container__comments--days">
+                        ${comment.created_at}
+                      </div>
+                    </div>
                   </div>`
       return html;
     }

--- a/app/assets/stylesheets/modules/comments.scss
+++ b/app/assets/stylesheets/modules/comments.scss
@@ -20,11 +20,19 @@
     color: white;
   }
   &__comments {
-    margin-left: 300px;
+    margin-left: 150px;
     font-size: 20px;
+    &--all {
+      display: flex;
+    }
     &--name {
       text-decoration: none;
       color: black;
+    }
+    &--days {
+      padding-left: 50px;
+      color: #666666;
+      font-size: 15px;
     }
   }
 }

--- a/app/views/comments/create.json.jbuilder
+++ b/app/views/comments/create.json.jbuilder
@@ -1,3 +1,4 @@
 json.text @comment.text
 json.user_id @comment.user.id
 json.user_name @comment.user.name
+json.created_at @comment.created_at.strftime("%Y年%m月%d日 %H:%M")

--- a/app/views/posts/show.html.haml
+++ b/app/views/posts/show.html.haml
@@ -28,9 +28,12 @@
         ＜コメント一覧＞
         - if @comments
           - @comments.each do |comment|
-            .container__comments--box
-              = link_to "#{comment.user.name}&nbsp;：".html_safe, "/users/#{comment.user_id}", class: "container__comments--name"
-              = comment.text
+            .container__comments--all
+              .container__comments--box
+                = link_to "#{comment.user.name}&nbsp;：".html_safe, "/users/#{comment.user_id}", class: "container__comments--name"
+                = comment.text
+              .container__comments--days
+                = comment.created_at.strftime("%Y年%m月%d日 %H:%M")
 
     .maps
       場所検索→


### PR DESCRIPTION
## What
投稿へのコメントの際、日時も含めて表示する。
## Why
コメントの日時表示をすることで、ユーザー間のやり取りが行いやすくなるため。