### PR TITLE
投稿検索時の検索名の表示

### DIFF
--- a/app/assets/stylesheets/modules/posts.scss
+++ b/app/assets/stylesheets/modules/posts.scss
@@ -90,7 +90,7 @@
   width: 100%;
   background-image: url("737ceb674dd14f551a3fe4e51d7b8be5.png");
   &__search {
-    margin-left: 350px;
+    text-align: center;
     &--text {
       height: 40px;
       width: 200px;
@@ -132,6 +132,9 @@
       padding: 8px 16px;
       margin: 30px;
       background: #d14;
+      &__search {
+        font-size: 40px;
+      }
       &:before{
           content: "";
           position: absolute;

--- a/app/controllers/posts/searches_controller.rb
+++ b/app/controllers/posts/searches_controller.rb
@@ -1,5 +1,6 @@
 class Posts::SearchesController < ApplicationController
   def index
     @posts = Post.search(params[:keyword]).includes(:user)
+    @search_name = params[:keyword]
   end
 end

--- a/app/views/posts/searches/index.html.haml
+++ b/app/views/posts/searches/index.html.haml
@@ -11,8 +11,17 @@
       %i.fas.fa-plus-circle
 
   .main-space__contents
+    .main-space__search
+      = form_tag posts_searches_path, local: true, method: :get do
+        = text_field_tag :keyword, "#{@search_name}", class: "main-space__search--text"
+        = submit_tag "検索", class: "main-space__search--btn"
     .main-space__info--name
-      検索結果
+      - if @search_name == ""
+        検索結果：該当なし
+      - else
+        %span.main-space__info--name__search
+          = "#{@search_name}"
+        の検索結果
     .search-result
     - @posts.each do |post|
       .main-space__contents--title


### PR DESCRIPTION
## What
投稿検索時、検索結果に検索した名前の表示と、検索バーに検索した名前を残す実装。
## Why
検索機能の使いやすさの向上のため。